### PR TITLE
TE-4338 Fix up phpstan L5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "scripts": {
+    "cs-check": "phpcs --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/",
+    "cs-fix": "phpcbf --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/"
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "1.0.x-dev"
     }
-  },
-  "scripts": {
-    "cs-check": "phpcs --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/",
-    "cs-fix": "phpcbf --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/"
   },
   "config": {
     "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,10 @@
       "dev-master": "1.0.x-dev"
     }
   },
+  "scripts": {
+    "cs-check": "phpcs --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/",
+    "cs-fix": "phpcbf --standard=vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml -p src/"
+  },
   "config": {
     "sort-packages": true
   }

--- a/phpstan.json
+++ b/phpstan.json
@@ -1,3 +1,3 @@
 {
-  "defaultLevel": 4
+  "defaultLevel": 5
 }

--- a/src/SprykerEco/Zed/Loggly/Communication/Plugin/LogglyLoggerQueueMessageProcessorPlugin.php
+++ b/src/SprykerEco/Zed/Loggly/Communication/Plugin/LogglyLoggerQueueMessageProcessorPlugin.php
@@ -24,7 +24,7 @@ class LogglyLoggerQueueMessageProcessorPlugin extends AbstractPlugin implements 
      *
      * @return \Generated\Shared\Transfer\QueueReceiveMessageTransfer[]
      */
-    public function processMessages(array $queueMessageTransfers)
+    public function processMessages(array $queueMessageTransfers): array
     {
         try {
             $data = '';
@@ -62,7 +62,7 @@ class LogglyLoggerQueueMessageProcessorPlugin extends AbstractPlugin implements 
      *
      * @return int
      */
-    public function getChunkSize()
+    public function getChunkSize(): int
     {
         return $this->getConfig()->getQueueChunkSize();
     }

--- a/src/SprykerEco/Zed/Loggly/LogglyConfig.php
+++ b/src/SprykerEco/Zed/Loggly/LogglyConfig.php
@@ -19,9 +19,9 @@ class LogglyConfig extends AbstractBundleConfig
     public const ENDPOINT_BULK = 'bulk';
 
     /**
-     * @return \Spryker\Shared\Config\Config
+     * @return string
      */
-    public function getLogglyToken()
+    public function getLogglyToken(): string
     {
         return $this->get(LogglyConstants::TOKEN);
     }
@@ -29,7 +29,7 @@ class LogglyConfig extends AbstractBundleConfig
     /**
      * @return string
      */
-    public function getEndpoint()
+    public function getEndpoint(): string
     {
         return sprintf('https://%s/%s/%s/', static::HOST, static::ENDPOINT_BULK, $this->getLogglyToken());
     }
@@ -37,7 +37,7 @@ class LogglyConfig extends AbstractBundleConfig
     /**
      * @return string
      */
-    public function getQueueName()
+    public function getQueueName(): string
     {
         return $this->get(LogglyConstants::QUEUE_NAME, static::DEFAULT_QUEUE_NAME);
     }
@@ -45,7 +45,7 @@ class LogglyConfig extends AbstractBundleConfig
     /**
      * @return int
      */
-    public function getQueueChunkSize()
+    public function getQueueChunkSize(): int
     {
         return $this->get(LogglyConstants::QUEUE_CHUNK_SIZE, 50);
     }

--- a/tooling.yml
+++ b/tooling.yml
@@ -1,0 +1,2 @@
+code-sniffer:
+  level: 2


### PR DESCRIPTION
- Developer(s): @dereuromark

- Ticket: TE-4338

- Release Group: URL_HERE


#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Loggly                | minor (currently 0.0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Loggly

##### Change log

Initial Release

First release of Loggly module.
This module can be used when Log entries should be sent from a queue to [Loggly](https://www.loggly.com/).

